### PR TITLE
[ci skip] adding user @laestrada

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @LiamBindle @WilliamDowns @lizziel @msulprizio @yantosca
+* @laestrada

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - laestrada
     - WilliamDowns
     - yantosca
     - lizziel


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @laestrada as instructed in #7.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #7